### PR TITLE
Configure gh-pages domain

### DIFF
--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -32,3 +32,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/.vitepress/dist
+          cname: openauthcert.org


### PR DESCRIPTION
## Summary
- ensure GitHub Pages deployment sets up custom domain

## Testing
- `npm run build --silent`

------
https://chatgpt.com/codex/tasks/task_e_685497830b448323828735228ee72968