### PR TITLE
Update registry schema and docs

### DIFF
--- a/docs/badges.md
+++ b/docs/badges.md
@@ -4,6 +4,8 @@ Here you can find the currently defined certification badges issued by the **Ope
 
 Each badge represents a verified commitment to baseline identity access — without enterprise-only restrictions.
 
+Badges are issued for a specific **major version** of a project. Should a future release remove free SSO or IdP capabilities, the badge will expire or be revoked. Only OIDC, SAML, and LDAP protocols are eligible for certification, and all submission material must be in English.
+
 ---
 
 ## 🆓 `free-sso-idp`

--- a/docs/vendors.md
+++ b/docs/vendors.md
@@ -10,7 +10,9 @@ Each entry represents a public commitment to ethical identity integration, free 
 
 - 🌐 Website: [acme.example.com](https://acme.example.com)
 - 🧩 Repository: [github.com/acme/openidp](https://github.com/acme/openidp)
-- 🏷️ Badge: `free-sso-idp` v0.1
+- 📖 Documentation: [acme.example.com/docs](https://acme.example.com/docs)
+- 🏷️ Badge: `free-sso-idp` v0.1 (major version certified: 1)
+- 🔢 Version: 1.0.0
 - 📅 Certified: 2025-06-18
 - 🔒 Self-hostable: Yes
 - 📝 Notes:
@@ -21,6 +23,8 @@ Each entry represents a public commitment to ethical identity integration, free 
 Want your project listed?
 - Visit [badge-spec](https://github.com/openauthcert/badge-spec) to review available badges
 - Submit a registry entry via PR to [vendor-registry](https://github.com/openauthcert/vendor-registry)
+
+Only OIDC, SAML, and LDAP integrations qualify for certification. Certification applies to the vendor's **major version** noted above. Badges may be revoked if later releases remove free SSO or IdP access. All submissions and documentation must be provided in English.
 
 🧠 Transparent, verifiable, and forever free.
 

--- a/src/components/VendorDetail.vue
+++ b/src/components/VendorDetail.vue
@@ -1,9 +1,13 @@
 <template>
   <div v-if="vendor">
     <h1 class="text-2xl font-bold mb-2">{{ vendor.name }}</h1>
-    <div class="mb-2">
-      <span v-if="vendor.oidc" class="text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">OIDC</span>
-      <span v-if="vendor.saml" class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded ml-1">SAML</span>
+    <div class="text-sm text-gray-600 mb-1">Version: v{{ vendor.version }}</div>
+    <div class="mb-2 flex items-center space-x-2">
+      <img :src="`https://ghcr.io/openauthcert/badges/${vendor.badges[0].id}.svg`" :alt="vendor.badges[0].id" class="h-6" />
+      <span class="text-xs text-gray-700">badge v{{ vendor.badges[0].version }}</span>
+      <span v-if="vendor.auth.oidc" class="text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">OIDC</span>
+      <span v-if="vendor.auth.saml" class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded">SAML</span>
+      <span v-if="vendor.auth.ldap" class="text-xs bg-yellow-100 text-yellow-800 px-2 py-0.5 rounded">LDAP</span>
     </div>
     <div class="mb-2 text-sm">License: {{ vendor.license }}</div>
     <a :href="vendor.repo" target="_blank" class="text-blue-500 underline">GitHub Repository</a>

--- a/src/components/VendorList.vue
+++ b/src/components/VendorList.vue
@@ -21,10 +21,13 @@
         <router-link :to="'/registry/' + vendor.slug" class="text-xl font-semibold text-blue-600 hover:underline">
           {{ vendor.name }}
         </router-link>
+        <div class="text-sm text-gray-600">v{{ vendor.version }}</div>
         <div class="mt-2 flex items-center space-x-2">
           <img :src="`https://ghcr.io/openauthcert/badges/${vendor.badges[0].id}.svg`" :alt="vendor.badges[0].id" class="h-6" />
-          <span v-if="vendor.oidc" class="text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">OIDC</span>
-          <span v-if="vendor.saml" class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded">SAML</span>
+          <span class="text-xs text-gray-700">badge v{{ vendor.badges[0].version }}</span>
+          <span v-if="vendor.auth.oidc" class="text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">OIDC</span>
+          <span v-if="vendor.auth.saml" class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded">SAML</span>
+          <span v-if="vendor.auth.ldap" class="text-xs bg-yellow-100 text-yellow-800 px-2 py-0.5 rounded">LDAP</span>
         </div>
         <div class="text-sm text-gray-600 mt-1">License: {{ vendor.license }}</div>
         <a :href="vendor.repo" class="text-sm text-blue-500 underline" target="_blank">Source</a>
@@ -47,8 +50,8 @@ const licenses = Array.from(new Set(registry.map(r => r.license))).filter(Boolea
 const filtered = computed(() => {
   return registry.filter(v => {
     const matchesSearch = v.name.toLowerCase().includes(search.value.toLowerCase());
-    const matchesOIDC = !filterOIDC.value || v.oidc;
-    const matchesSAML = !filterSAML.value || v.saml;
+    const matchesOIDC = !filterOIDC.value || v.auth.oidc;
+    const matchesSAML = !filterSAML.value || v.auth.saml;
     const matchesLicense = !filterLicense.value || v.license === filterLicense.value;
     return matchesSearch && matchesOIDC && matchesSAML && matchesLicense;
   });

--- a/src/data/registry.json
+++ b/src/data/registry.json
@@ -1,12 +1,17 @@
 [
   {
     "slug": "acme",
-    "oidc": true,
-    "saml": false,
-    "license": "Unknown",
     "name": "Acme Identity Hub",
+    "version": "1.0.0",
     "website": "https://acme.example.com",
     "repo": "https://github.com/acme/openidp",
+    "documentation": "https://acme.example.com/docs",
+    "license": "Unknown",
+    "auth": {
+      "oidc": true,
+      "saml": false,
+      "ldap": true
+    },
     "badges": [
       {
         "id": "free-sso-idp",


### PR DESCRIPTION
## Summary
- restructure vendor registry to use auth info and add documentation and version fields
- display certified major version and badge version in UI
- clarify badge and vendor docs about major version, revocation, valid protocols, and English requirement

## Testing
- `npm run dev-app`

------
https://chatgpt.com/codex/tasks/task_e_6856ea36e5c88323a70c75038b5ca367