### PR TITLE
Clean up docs navigation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -10,47 +10,13 @@ export default defineConfig({
     siteTitle: '',
 
     nav: [
-      { text: 'Home', link: '/' },
+      { text: 'Docs', link: '/' },
       { text: 'Badges', link: '/badges' },
       { text: 'Vendors', link: '/vendors' },
-      { text: 'Docs', link: '/external/' },
       { text: 'GitHub', link: 'https://github.com/openauthcert' }
     ],
 
     sidebar: {
-      '/external/': [
-        {
-          text: 'Governance',
-          items: [
-            { text: 'Foundation', link: '/external/governance/foundation' },
-            { text: 'Contributor Council', link: '/external/governance/contributor-council' },
-            { text: 'Decision Process', link: '/external/governance/decision-process' }
-          ]
-        },
-        {
-          text: 'Certification',
-          items: [
-            { text: 'Badge Lifecycle', link: '/external/certification/badge-lifecycle' },
-            { text: 'Criteria v0.1', link: '/external/certification/criteria-v0.1' },
-            { text: 'Application Process', link: '/external/certification/application-process' },
-            { text: 'Revocation Policy', link: '/external/certification/revocation-policy' }
-          ]
-        },
-        {
-          text: 'Policies',
-          items: [
-            { text: 'Code of Conduct', link: '/external/policies/code-of-conduct' },
-            { text: 'Data Usage', link: '/external/policies/data-usage' },
-            { text: 'Legal Notice', link: '/external/policies/legal-notice' }
-          ]
-        },
-        {
-          text: 'General',
-          items: [
-            { text: 'FAQ', link: '/external/faq' }
-          ]
-        }
-      ],
       '/': [
         {
           text: 'Certification',


### PR DESCRIPTION
## Summary
- remove `/external` docs section and associated navigation
- rename Home link to Docs for clarity

## Testing
- `npm install`
- `CI=1 npx vitepress build docs`

------
https://chatgpt.com/codex/tasks/task_e_6856fd7a5128832388c56c09d99a25d1